### PR TITLE
Modify importing

### DIFF
--- a/fuzzer/data_analysis.py
+++ b/fuzzer/data_analysis.py
@@ -20,11 +20,12 @@ import argparse
 import sys
 import random
 import pickle
-from bit_parser import print_frame
+#from bit_parser import print_frame
 from bit_parser import parse_bitstream
 
 from jpype.types import *
-from data_generator import *
+#import data_generator as dg
+
 from com.xilinx.rapidwright.device import Device
 from com.xilinx.rapidwright.device import Series
 from com.xilinx.rapidwright.design import Design

--- a/fuzzer/data_generator.py
+++ b/fuzzer/data_generator.py
@@ -22,22 +22,24 @@ import sys
 import random
 from multiprocessing import Pool
 
-fj = open("vivado_db/primitive_dict.json")
-primitive_dict = json.load(fj) 
-fj.close()
-fj = open("vivado_db/bel_dict.json")
-bel_dict = json.load(fj) 
-fj.close()
-fj = open("vivado_db/tile_dict.json")
-tile_dict = json.load(fj) 
-fj.close()
-fj = open("vivado_db/tilegrid.json")
-tilegrid = json.load(fj) 
-fj.close()
+def data_generator_init():
+    global primitive_dict, bel_dict, tile_dict, tilegrid, tile_type, ft, specimen_number
+    fj = open("vivado_db/primitive_dict.json")
+    primitive_dict = json.load(fj) 
+    fj.close()
+    fj = open("vivado_db/bel_dict.json")
+    bel_dict = json.load(fj) 
+    fj.close()
+    fj = open("vivado_db/tile_dict.json")
+    tile_dict = json.load(fj) 
+    fj.close()
+    fj = open("vivado_db/tilegrid.json")
+    tilegrid = json.load(fj) 
+    fj.close()
 
-tile_type = ""
-ft = ""
-specimen_number = 0
+    tile_type = ""
+    ft = ""
+    specimen_number = 0
 
 ##================================================================================##
 ##                                CREATE TCL SCRIPT                               ##

--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -27,7 +27,28 @@ from time import sleep
 import jpype
 import jpype.imports
 from jpype.types import *
-jpype.startJVM(classpath=["rapidwright-2021.2.0-standalone-lin64.jar"])
+
+import pips_rapid
+import data_analysis
+import data_generator as dg
+#from pip_generator import *
+import rapid_tilegrid
+#from tilegrid_solver import *
+
+def make_folders():  
+    if args.diff_folder != "NONE":
+        return args.diff_folder
+    for x in ["data","checkpoints","vivado_db","db", "fuzzer_data"]:
+        try: 
+            os.makedirs(args.family + "/" + args.part + "/" + x + "/", exist_ok=True)
+        except OSError as error: 
+            print(error)  
+    for i in range(1000):
+        if os.path.exists(args.family + "/" + args.part + "/data/" + str(i).zfill(4)) == False:
+            os.mkdir(args.family + "/" + args.part + "/data/" + str(i).zfill(4))
+            return str(i).zfill(4)
+
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument('tile_type', nargs=1)                   # Selects the target tile type
@@ -62,50 +83,26 @@ if os.path.exists(args.family + "/" + args.part + "/vivado_db/init.dcp") == Fals
     is_first_run = 1
     os.system("vivado -mode batch -source get_db.tcl -tclarg " + args.family + " " + args.part)
 
-
-def make_folders():  
-    if args.diff_folder != "NONE":
-        return args.diff_folder
-    for x in ["data","checkpoints","vivado_db","db", "fuzzer_data"]:
-        try: 
-            os.makedirs(args.family + "/" + args.part + "/" + x + "/", exist_ok=True)
-        except OSError as error: 
-            print(error)  
-    for i in range(1000):
-        if os.path.exists(args.family + "/" + args.part + "/data/" + str(i).zfill(4)) == False:
-            os.mkdir(args.family + "/" + args.part + "/data/" + str(i).zfill(4))
-            return str(i).zfill(4)
-
 top_fuzz_path = make_folders()
 print("Running in directory: " + top_fuzz_path, file = sys.stderr)
 
-
 os.chdir(args.family + "/" + args.part + "/")
-
-from pips_rapid import *
-from data_analysis import *
-from data_generator import *
-#from pip_generator import *
-from rapid_tilegrid import *
-#from tilegrid_solver import *
-
-
-    
 
 ##================================================================================##
 ##                                  CONTROL                                       ##
 ##================================================================================##
 
+jpype.startJVM(classpath=["rapidwright-2021.2.0-standalone-lin64.jar"])
 
 if is_first_run == 1:
-    run_tilegrid_solver(args)
+    rapid_tilegrid.run_tilegrid_solver(args)
 
 if int(args.pips) == 1 and int(args.fuzzer) == 1:
-    run_pip_fuzzer(top_fuzz_path,args)
+    pips_rapid.run_pip_fuzzer(top_fuzz_path,args)
 elif int(args.fuzzer) == 1:
-    run_data_generator(top_fuzz_path,args)
+    dg.run_data_generator(top_fuzz_path,args)
     
-run_data_analysis(top_fuzz_path,args)
+data_analysis.run_data_analysis(top_fuzz_path,args)
         
 os.chdir("../..")
 

--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -28,6 +28,9 @@ import jpype
 import jpype.imports
 from jpype.types import *
 
+# Next line needs to be run before any com.xilinx.rapidwright.. things can be imported (like in pips_rapid.py)
+jpype.startJVM(classpath=["rapidwright-2021.2.0-standalone-lin64.jar"])
+
 import pips_rapid
 import data_analysis
 import data_generator as dg
@@ -92,7 +95,6 @@ os.chdir(args.family + "/" + args.part + "/")
 ##                                  CONTROL                                       ##
 ##================================================================================##
 
-jpype.startJVM(classpath=["rapidwright-2021.2.0-standalone-lin64.jar"])
 
 if is_first_run == 1:
     rapid_tilegrid.run_tilegrid_solver(args)

--- a/fuzzer/fuzzer.py
+++ b/fuzzer/fuzzer.py
@@ -38,6 +38,7 @@ import data_generator as dg
 import rapid_tilegrid
 #from tilegrid_solver import *
 
+
 def make_folders():  
     if args.diff_folder != "NONE":
         return args.diff_folder
@@ -91,10 +92,8 @@ print("Running in directory: " + top_fuzz_path, file = sys.stderr)
 
 os.chdir(args.family + "/" + args.part + "/")
 
-##================================================================================##
-##                                  CONTROL                                       ##
-##================================================================================##
-
+# The data_generator module needs to pre-load a bunch of database files before it can do its work
+dg.data_generator_init()
 
 if is_first_run == 1:
     rapid_tilegrid.run_tilegrid_solver(args)

--- a/fuzzer/pip_generator.py
+++ b/fuzzer/pip_generator.py
@@ -21,7 +21,7 @@ import argparse
 import sys
 import random
 import pickle
-from data_generator import *
+import data_generator as dg
 from data_analysis import parse_feature_file
 
 
@@ -36,20 +36,20 @@ def create_pip_design():
     site_pin_bel_pin_dict = {}
     primitive_placement_dict = {}
     ft = open("data/" + fuzz_path + "/pip.tcl","w",buffering=1)
-    set_ft(ft)
+    dg.set_ft(ft)
     print("source ../../record_device.tcl",file=ft)
     print("source ../../drc.tcl",file=ft)
     print("source ../../fuzz_pip.tcl",file=ft)
     print("set ::family " + args.family,file=ft)
     print("set part_name " + args.part,file=ft)
-    init_design()
+    dg.init_design()
     place_tile_types = ["CLBLL_L","CLBLL_R","CLBLM_L","CLBLM_R","CLE_M_R","CLE_M","CLEL_L","CLEL_R"]
     for tile_type in tile_dict["TILE_TYPE"].keys():
         for i in tile_dict["TILE_TYPE"][tile_type]["SITE_INDEX"].keys():
             tile_list = []
-            for T in tilegrid:
-                if tile_type == tilegrid[T]["TYPE"]:
-                    if "IS_BONDED" not in tilegrid[T] or tilegrid[T]["IS_BONDED"] == True:
+            for T in dg.tilegrid:
+                if tile_type == dg.tilegrid[T]["TYPE"]:
+                    if "IS_BONDED" not in dg.tilegrid[T] or dg.tilegrid[T]["IS_BONDED"] == True:
                         tile_list.append(T)
 
             db = tile_dict["TILE_TYPE"][tile_type]["SITE_INDEX"][i]
@@ -94,16 +94,16 @@ def create_pip_design():
                         placement_str = ""
                         for x in range(len(tile_list)):
                             cell_name_str += "C_" + str(cell_count) + " "
-                            placement_str += place_cell_str(tile_list[x],i,B,cell_count) + " "
+                            placement_str += dg.place_cell_str(tile_list[x],i,B,cell_count) + " "
                             cell_count += 1
-                        create_cells(P, cell_name_str)
-                        pre_placement_drc(checkpoint_name,tile_list)
-                        place_cells(placement_str)
+                        dg.create_cells(P, cell_name_str)
+                        dg.pre_placement_drc(checkpoint_name,tile_list)
+                        dg.place_cells(placement_str)
     #DRC Fixes
-    post_placement_drc(1)
+    dg.post_placement_drc(1)
     fs = open("vivado_db/site_pin_dict.txt","w",buffering=1)
     fj = open("vivado_db/placement_tcl_dict.txt","w",buffering=1)
-    write_checkpoint("vivado_db/pip")
+    dg.write_checkpoint("vivado_db/pip")
     os.system("vivado -mode batch -source data/" + fuzz_path + "/pip.tcl -stack 2000")
     site_pin_dict = ""
     for x in site_pin_bel_pin_dict:
@@ -166,11 +166,11 @@ def fuzz_pips():
     pips_per_bitstream = 80
     
     ft = open("data/" + fuzz_path + "/fuzz_pips.tcl","w",buffering=1)
-    set_ft(ft)
+    dg.set_ft(ft)
     print("source ../../record_device.tcl",file=ft)
     print("source ../../drc.tcl",file=ft)
-    open_checkpoint("vivado_db/pip")
-    disable_drc()
+    dg.open_checkpoint("vivado_db/pip")
+    dg.disable_drc()
     print("source ../../fuzz_pip.tcl",file=ft)
     print("set ::family " + args.family,file=ft)
     print("set part_name " + args.part,file=ft)
@@ -180,7 +180,7 @@ def fuzz_pips():
 
     tile_list = get_tile_list(tile_type)
     count = 0
-    values = list(bel_dict["TILE_TYPE"][tile_type]["TILE_PIP"].keys())
+    values = list(dg.bel_dict["TILE_TYPE"][tile_type]["TILE_PIP"].keys())
     random.shuffle(values)
     random.shuffle(tile_list)
     for P in values:
@@ -189,16 +189,16 @@ def fuzz_pips():
             count += 1
             if count >= pips_per_bitstream:
                 count = 0
-                pip_bitstream_drc()
+                dg.pip_bitstream_drc()
                 #write_checkpoint("data/" + fuzz_path + "/" + str(specimen_number) + ".pips")
                 print("record_device_pips data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.ft",file=ft)
-                write_bitstream("data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.bit")
+                dg.write_bitstream("data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.bit")
                 specimen_number+=1
-                open_checkpoint("vivado_db/pip")
+                dg.open_checkpoint("vivado_db/pip")
                 print("init_pip_fuzzer " + tile_type,file=ft)
-    pip_bitstream_drc()
+    dg.pip_bitstream_drc()
     print("record_device_pips data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.ft",file=ft)
-    write_bitstream("data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.bit")
+    dg.write_bitstream("data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.bit")
     specimen_number+=1
     os.system("vivado -mode batch -source data/" + fuzz_path + "/fuzz_pips.tcl")
     
@@ -210,7 +210,7 @@ def run_pip_generator(in_fuzz_path,in_args):
     tile_type = in_args.tile_type[0]
     fuzz_path = in_fuzz_path
     args = in_args
-    set_args(in_args)
+    dg.set_args(in_args)
 
     fj = open("vivado_db/tile_dict.json")
     tile_dict = json.load(fj) 

--- a/fuzzer/pips_rapid.py
+++ b/fuzzer/pips_rapid.py
@@ -18,6 +18,7 @@
 import random
 import re
 import json
+import sys
 import os
 import os.path
 from os import path
@@ -25,7 +26,7 @@ import datetime
 import jpype
 import jpype.imports
 from jpype.types import *
-from data_generator import *
+import data_generator as dg
 from data_analysis import parse_feature_file
 #jpype.startJVM(classpath=["rapidwright-2021.1.1-standalone-lin64.jar"])
 
@@ -667,13 +668,13 @@ def export_path(path_up, site_pin_up,path_down, site_pin_down,net_name):
 
 def generate_pip_bitstream():
     global fuzz_path, specimen_number, tile_type
-    post_placement_drc(1)
+    dg.post_placement_drc(1)
     add_nets()
-    pip_bitstream_drc()
+    dg.pip_bitstream_drc()
     print("record_device_pips data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.ft",file=ft)
-    write_bitstream("data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.bit")
+    dg.write_bitstream("data/" + fuzz_path + "/" + str(specimen_number) + "." + tile_type + ".pips.bit")
     specimen_number+=1
-    open_checkpoint("vivado_db/init")
+    dg.open_checkpoint("vivado_db/init")
     return 
 
 def add_used_site(site_pin):
@@ -1048,11 +1049,11 @@ def init_file():
     """
     global ft, fuzz_path, args
     ft = open("data/" + fuzz_path + "/fuzz_pips.tcl","w",buffering=1)
-    set_ft(ft)
+    dg.set_ft(ft)
     print("source ../../record_device.tcl",file=ft)
     print("source ../../drc.tcl",file=ft)
-    open_checkpoint("vivado_db/init")
-    disable_drc()
+    dg.open_checkpoint("vivado_db/init")
+    dg.disable_drc()
     #print("source ../../fuzz_pip.tcl",file=ft)
     print("set ::family " + args.family,file=ft)
     print("set part_name " + args.part,file=ft)
@@ -1076,7 +1077,7 @@ def run_pip_fuzzer(in_fuzz_path,in_args):
     tile_type = in_args.tile_type[0]
     fuzz_path = in_fuzz_path
     args = in_args
-    set_args(in_args)   # In data_generator.py
+    dg.set_args(in_args)   # In data_generator.py
     nets = []
     fj = open("vivado_db/primitive_dict.json")
     primitive_dict = json.load(fj) 

--- a/fuzzer/rapid_tilegrid.py
+++ b/fuzzer/rapid_tilegrid.py
@@ -23,7 +23,7 @@ import pickle
 import os
 from jpype.types import *
 
-from data_generator import *
+import data_generator as dg
 from data_analysis import parse_feature_file
 #jpype.startJVM(classpath=["rapidwright-2021.1.1-standalone-lin64.jar"])
 
@@ -38,34 +38,34 @@ from com.xilinx.rapidwright.bitstream import Frame
 def get_int_tile_dict():
     global args, int_tile_dict
     int_tile_dict = {}
-    for T in tilegrid:
-        if tilegrid[T]["TYPE"] in ["INT_L", "INT_R", "INT"]:
+    for T in dg.tilegrid:
+        if dg.tilegrid[T]["TYPE"] in ["INT_L", "INT_R", "INT"]:
             if args.family in ["artix7","spartan7","kintex7","virtex7"]:
-                int_tile_dict[tilegrid[T]["TILE_Y"]] = tilegrid[T]["Y"]%50
+                int_tile_dict[dg.tilegrid[T]["TILE_Y"]] = dg.tilegrid[T]["Y"]%50
             else:
-                int_tile_dict[tilegrid[T]["TILE_Y"]] = tilegrid[T]["Y"]%60
+                int_tile_dict[dg.tilegrid[T]["TILE_Y"]] = dg.tilegrid[T]["Y"]%60
 
 
 def get_byte_offset(RT):
     global args, int_tile_dict
     T = str(RT)
-    height = tilegrid[T]["HEIGHT"]
+    height = dg.tilegrid[T]["HEIGHT"]
     if args.family in ["artix7", "spartan7","kintex7","virtex7","zynq7"]:
         crc = [50]
         if height == 2:
-            int_y = tilegrid[T]["TILE_Y"]
+            int_y = dg.tilegrid[T]["TILE_Y"]
         elif height%2 == 0:
-            int_y = tilegrid[T]["TILE_Y"] - int(height/4*3200) + 1600
+            int_y = dg.tilegrid[T]["TILE_Y"] - int(height/4*3200) + 1600
         else:
-            int_y = tilegrid[T]["TILE_Y"] - (int(height/4))*3200
+            int_y = dg.tilegrid[T]["TILE_Y"] - (int(height/4))*3200
         words_per_int = 2
     elif args.family in ["kintexu","zynqu","virtexu"]:
         crc = [60,61,62]
-        int_y = tilegrid[T]["TILE_Y"]
+        int_y = dg.tilegrid[T]["TILE_Y"]
         words_per_int = 2
     else:
         crc = [90,91,92,93,94,95]
-        int_y = tilegrid[T]["TILE_Y"]
+        int_y = dg.tilegrid[T]["TILE_Y"]
         words_per_int = 3
     
     if int_y not in int_tile_dict:
@@ -209,7 +209,7 @@ def run_tilegrid_solver(in_args):
     global args, tile_type, tile_dict, primitive_map, nets, ft, specimen_number
     #tile_type = in_args.tile_type[0]
     args = in_args
-    set_args(in_args)
+    dg.set_args(in_args)
     init_rapidwright(args.part)
     get_int_tile_dict()
     get_blocks()


### PR DESCRIPTION
1. Changed "from data_generator import *" statements to "import data_generator as dg".  
2. This also required qualifying a few function calls to routines inside data_generator with the ".dg"prefix in the calling modules.
3. Collected non-function initialization code in data_generator.py into a subroutine (data_generator_init) to be called by fuzzer.py.
4. Did similar things for other modules.5. 
5. The above changes ma\ke it possible to change fuzzer.py to have all its imports up top rather than have to mix them down through the executable script code.

Two reasons for the changes.  #1 = The use if import * is discouraged in that it pollutes the importing module's namespace with everything in the imported module's namespace.  #2= It makes the code more explicit of where things are coming from so that others learning the code and its structure can more quickly come up to speed.

